### PR TITLE
[Composer] Allowed ezpublish-kernel 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "ezsystems/ezpublish-kernel": "^6.8"
+    "ezsystems/ezpublish-kernel": "^6.8 || ^7.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR allows ezpublish-kernel 7.0 to be able to use this package with eZ Platform EE 2.0.

Note: targeting this to `1.5` as master is behind.

- [x] Allow ezpublish-kernel 7.0