### PR TITLE
EZEE-1870: Add main location to 'eZ Platform' (Content ID: 1)

### DIFF
--- a/Resources/sql/cleandata.sql
+++ b/Resources/sql/cleandata.sql
@@ -53,4 +53,7 @@ INSERT INTO `ezurlalias_ml_incr` VALUES (38);
 UPDATE `ezcontentobject_tree` SET contentobject_id=52, contentobject_version=1, path_identification_string='', remote_id='f3e90596361e31d496d4026eb624c983' WHERE path_string='/1/2/';
 INSERT INTO `ezcontentobject_tree` VALUES (53,1,1,3,0,0,54,1486473151,54,52,'media/files/form_uploads','/1/43/52/54/',0,'0543630fa051a1e2be54dbd32da2420f',1,1);
 
+-- adds location for 'eZ Platform' which was previously detached
+INSERT INTO `ezcontentobject_tree` (`contentobject_id`, `contentobject_is_published`, `contentobject_version`, `depth`, `is_hidden`, `is_invisible`, `main_node_id`, `modified_subnode`, `node_id`, `parent_node_id`, `path_identification_string`, `path_string`, `priority`, `remote_id`, `sort_field`, `sort_order`) VALUES (1,1,9,1,0,0,3,1301073466,3,1,'node_3','/1/3/',0,'80a0766c8c1169fc9f9560bcaa51c1ed',8,1);
+
 INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (482,251,'3');


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1870

# Description
EZEE installer was swapping location in order to put landing page under `/1/2` but it was leaving `eZ Platform` (Content ID: 1) without any location. I'd like to hear how this should be handled in a better way but at least this seems to be least intrusive method. Ideally Home should have new location but I'd rather not change IDs at the moment (BC break).