### PR TITLE
[EZEE-1870] Adding missing location to community landing page and nes…

### DIFF
--- a/Resources/sql/cleandata.sql
+++ b/Resources/sql/cleandata.sql
@@ -22,4 +22,6 @@ INSERT INTO `ezcobj_state_link` VALUES (52,1);
 
 UPDATE `ezcontentobject_tree` SET contentobject_id=52, contentobject_version=1, path_identification_string='', remote_id='f3e90596361e31d496d4026eb624c983' WHERE path_string='/1/2/';
 
-INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES (482,251,'3');
+INSERT INTO `ezcontentobject_tree` VALUES (1,1,1,3,0,0,42,1486473151,42,2,'home','/1/2/42/',0,'581da01017b80b1afb1e5e2a3081c724',1,1);
+
+INSERT INTO `ezpolicy_limitation_value` VALUES (482,251,'3');


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1870

# Description
EZEE installer was swapping location in order to put landing page under `/1/2` but it was leaving `eZ Platform` (Content ID: 1) without any location. It is now restored and nested under ee landing page.