### PR TITLE
EZEE-1922: Moving content located under 'eZ Platform' folder doesn't update ezcontentobject_tree.depth value

### DIFF
--- a/Resources/sql/cleandata.sql
+++ b/Resources/sql/cleandata.sql
@@ -22,6 +22,6 @@ INSERT INTO `ezcobj_state_link` VALUES (52,1);
 
 UPDATE `ezcontentobject_tree` SET contentobject_id=52, contentobject_version=1, path_identification_string='', remote_id='f3e90596361e31d496d4026eb624c983' WHERE path_string='/1/2/';
 
-INSERT INTO `ezcontentobject_tree` VALUES (1,1,1,3,0,0,42,1486473151,42,2,'home','/1/2/42/',0,'581da01017b80b1afb1e5e2a3081c724',1,1);
+INSERT INTO `ezcontentobject_tree` VALUES (1,1,1,2,0,0,42,1486473151,42,2,'home','/1/2/42/',0,'581da01017b80b1afb1e5e2a3081c724',1,1);
 
 INSERT INTO `ezpolicy_limitation_value` VALUES (482,251,'3');


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1922

This PR fixes value for `depth` field in `ezcontentobject_tree` table for studio-clean installation sql.