### PR TITLE
EZEE-2526: Missing index on ezpage_map_blocks_zones causes long query execution time

### DIFF
--- a/Resources/sql/schema.sql
+++ b/Resources/sql/schema.sql
@@ -106,7 +106,7 @@ DROP TABLE IF EXISTS `ezpage_map_blocks_zones`;
 CREATE TABLE `ezpage_map_blocks_zones` (
   `block_id` int(11) NOT NULL,
   `zone_id` int(11) NOT NULL,
-  INDEX `idx` (`block_id`, `zone_id`)
+  PRIMARY KEY (`block_id`, `zone_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `ezpage_map_zones_pages`;

--- a/Resources/sql/schema.sql
+++ b/Resources/sql/schema.sql
@@ -105,7 +105,8 @@ CREATE TABLE `ezpage_map_attributes_blocks` (
 DROP TABLE IF EXISTS `ezpage_map_blocks_zones`;
 CREATE TABLE `ezpage_map_blocks_zones` (
   `block_id` int(11) NOT NULL,
-  `zone_id` int(11) NOT NULL
+  `zone_id` int(11) NOT NULL,
+  INDEX `idx` (`block_id`, `zone_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `ezpage_map_zones_pages`;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | https://jira.ez.no/browse/EZEE-2526
| Versions      | `2.2`, `2.3`, `master`

Related PR in docs: https://github.com/ezsystems/developer-documentation/pull/424