### PR TITLE
EZEE-2582: Database reinstall fails on ezplatform-workflow package

### DIFF
--- a/Resources/sql/schema.sql
+++ b/Resources/sql/schema.sql
@@ -198,7 +198,11 @@ CREATE TABLE `ezform_form_submission_data` (
 -- Workflow
 --
 
+-- Drop tables first because they use foreign keys
+DROP TABLE IF EXISTS `ezeditorialworkflow_markings`;
+DROP TABLE IF EXISTS `ezeditorialworkflow_transitions`;
 DROP TABLE IF EXISTS `ezeditorialworkflow_workflows`;
+
 CREATE TABLE `ezeditorialworkflow_workflows` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `content_id` int(11) NOT NULL,
@@ -206,30 +210,19 @@ CREATE TABLE `ezeditorialworkflow_workflows` (
   `workflow_name` varchar(255) NOT NULL DEFAULT '',
   `initial_owner_id` int(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_workflow_id` (`id`)
+  KEY `idx_workflow_id` (`id`),
+  KEY `initial_owner_id` (`initial_owner_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-DROP TABLE IF EXISTS `ezeditorialworkflow_markings`;
 CREATE TABLE `ezeditorialworkflow_markings` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `workflow_id` int(11) unsigned NOT NULL,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `fk_workflow_id` (`workflow_id`),
-  CONSTRAINT `fk_workflow_id` FOREIGN KEY (`workflow_id`) REFERENCES `ezeditorialworkflow_workflows` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  CONSTRAINT `fk_ezeditorialworkflow_markings_workflow_id` FOREIGN KEY (`workflow_id`) REFERENCES `ezeditorialworkflow_workflows` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-DROP TABLE IF EXISTS `ezeditorialworkflow_places`;
-CREATE TABLE `ezeditorialworkflow_places` (
-  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `content_id` int(11) NOT NULL,
-  `version_no` int(11) NOT NULL,
-  `workflow_id` int(11) NOT NULL,
-  `place` varchar(255) NOT NULL DEFAULT '',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-DROP TABLE IF EXISTS `ezeditorialworkflow_transitions`;
 CREATE TABLE `ezeditorialworkflow_transitions` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `workflow_id` int(11) unsigned NOT NULL,
@@ -237,5 +230,7 @@ CREATE TABLE `ezeditorialworkflow_transitions` (
   `timestamp` int(11) NOT NULL,
   `user_id` int(11) DEFAULT NULL,
   `comment` text,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `fk_workflow_id` (`workflow_id`),
+  CONSTRAINT `fk_ezeditorialworkflow_transitions_workflow_id` FOREIGN KEY (`workflow_id`) REFERENCES `ezeditorialworkflow_workflows` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-2582

A followup PR to #37 as it was failing on dropping tables due to incorrect order and foreign keys. Now the issue is fixed. Also I removed `places` table which was not needed.