### PR TITLE
Fixing typo in key name for table ezpage_map_attributes_blocks

### DIFF
--- a/Resources/config/storage/schema.yaml
+++ b/Resources/config/storage/schema.yaml
@@ -156,8 +156,8 @@ tables:
       till: { type: integer, nullable: true }
   ezpage_map_attributes_blocks:
     indexes:
-      ezpage_map_attributes_attribute_id: { fields: [attribute_id] }
-      ezpage_map_attributes_block_id: { fields: [block_id] }
+      ezpage_map_attributes_blocks_attribute_id: { fields: [attribute_id] }
+      ezpage_map_attributes_blocks_block_id: { fields: [block_id] }
     id:
       attribute_id: { type: integer, nullable: false }
       block_id: { type: integer, nullable: false }


### PR DESCRIPTION
This PR fixes typo in key names for table `ezpage_map_attributes_blocks`, so it is consistent with other index names and https://github.com/ezsystems/developer-documentation/pull/706/files