### PR TITLE
Fixing typo in key name for table ezpage_map_attributes_blocks

### DIFF
--- a/Resources/sql/schema.sql
+++ b/Resources/sql/schema.sql
@@ -100,8 +100,8 @@ CREATE TABLE `ezpage_map_attributes_blocks` (
   `attribute_id` int(11) NOT NULL,
   `block_id` int(11) NOT NULL,
   PRIMARY KEY (`attribute_id`,`block_id`),
-  KEY `ezpage_map_attributes_attribute_id` (`attribute_id`),
-  KEY `ezpage_map_attributes_block_id` (`block_id`)
+  KEY `ezpage_map_attributes_blocks_attribute_id` (`attribute_id`),
+  KEY `ezpage_map_attributes_blocks_block_id` (`block_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `ezpage_map_blocks_zones`;


### PR DESCRIPTION
This PR fixes typo in key names for table ezpage_map_attributes_blocks, so it is consistent with other index names and https://github.com/ezsystems/developer-documentation/pull/706/files