### PR TITLE
EZP-30898: Refactored EE installer DIC to use CoreInstaller

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -1,10 +1,6 @@
-parameters:
-    ezplatform.ee.installer.class: EzSystems\EzPlatformEnterpriseEditionInstallerBundle\Installer\Installer
-
 services:
-    ezstudio.installer.studio_installer:
-        class: '%ezplatform.ee.installer.class%'
-        parent: ezplatform.installer.clean_installer
+    EzSystems\EzPlatformEnterpriseEditionInstallerBundle\Installer\Installer:
+        parent: EzSystems\PlatformInstallerBundle\Installer\CoreInstaller
         tags:
             - {name: ezplatform.installer, type: ezplatform-ee-clean}
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30898](https://jira.ez.no/browse/EZP-30898)
| **Requires** | ezsystems/ezpublish-kernel#2756
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (3.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

- [x] Changed in DIC Installer parent to `CoreInstaller` (actual class already extends that parent).

- [x] Renamed the `ezstudio.installer.studio_installer` service to the FQCN-named service `EzSystems\EzPlatformEnterpriseEditionInstallerBundle\Installer\Installer`.

- [x] Dropped the `ezplatform.ee.installer.class` DIC parameter.