### PR TITLE
Updated outdated Product name in clean data dumps

### DIFF
--- a/Resources/sql/mysql/cleandata.sql
+++ b/Resources/sql/mysql/cleandata.sql
@@ -81,7 +81,7 @@ INSERT INTO `ezpolicy_limitation_value` (`id`, `limitation_id`, `value`) VALUES
 -- Page for Home
 
 INSERT INTO `ezpage_attributes` (`id`, `name`, `value`)
-VALUES (1,'content','<h1>eZ Studio</h1> <p>This is the clean install coming with eZ Studio. Now you can start creating your own design.</p>');
+VALUES (1,'content','<h1>eZ Platform Enterprise Edition</h1> <p>This is the clean install coming with eZ Platform Enterprise Edition. Now you can start creating your own design.</p>');
 
 INSERT INTO `ezpage_blocks` (`id`, `type`, `view`, `name`)
 VALUES (1,'tag','default','Tag');

--- a/Resources/sql/postgresql/cleandata.sql
+++ b/Resources/sql/postgresql/cleandata.sql
@@ -66,7 +66,7 @@ INSERT INTO "ezpolicy_limitation_value" ("id", "limitation_id", "value") VALUES 
 -- Page for Home
 
 INSERT INTO "ezpage_attributes" ("id", "name", "value")
-VALUES (1,'content',E'<h1>eZ Studio</h1> <p>This is the clean install coming with eZ Studio. Now you can start creating your own design.</p>');
+VALUES (1,'content',E'<h1>eZ Platform Enterprise Edition</h1> <p>This is the clean install coming with eZ Platform Enterprise Edition. Now you can start creating your own design.</p>');
 
 INSERT INTO "ezpage_blocks" ("id", "type", "view", "name")
 VALUES (1,'tag','default','Tag');


### PR DESCRIPTION
This PR changes "eZ Studio" string in clean data dump for MySQL and PostgreSQL to "eZ Platform Enterprise Edition".

**Target version**: eZ Platform EE v3.0.0

### Open question
- [ ] Should we back-port it to 2.5.x? Would work for new installations only, so maybe not worth the effort

### Before:

![image](https://user-images.githubusercontent.com/7099219/77232256-3c5eb300-6ba0-11ea-874f-5a870f33b25e.png)

### After:

![image](https://user-images.githubusercontent.com/7099219/77232263-47b1de80-6ba0-11ea-8f52-86edb0ee6015.png)