### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "symfony/dependency-injection": "^5.0",
     "symfony/event-dispatcher": "^5.0"
   },
+  "require-dev": {
+    "ezsystems/doctrine-dbal-schema": "^1.0@dev"
+  },
   "autoload": {
     "psr-4": {
       "EzSystems\\EzPlatformEnterpriseEditionInstallerBundle\\": ""

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.3",
-    "ezsystems/ezpublish-kernel": "^8.0@dev",
+    "ezsystems/ezplatform-kernel": "^1.0@dev",
     "symfony/http-kernel": "^5.0",
     "symfony/config": "^5.0",
     "symfony/dependency-injection": "^5.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`
#### TODO
- [x] Manually check that package can be installed.