### PR TITLE
EZEE-3060: Added version independent schedule for content

### DIFF
--- a/Resources/config/storage/schema.yaml
+++ b/Resources/config/storage/schema.yaml
@@ -1,5 +1,5 @@
 tables:
-  ezdatebasedpublisher_scheduled_version:
+  ezdatebasedpublisher_scheduled_entries:
     uniqueConstraints:
       content_id_version_number_action: { fields: [content_id, version_number, action] }
     indexes:
@@ -9,8 +9,8 @@ tables:
       id: { type: integer, nullable: false, options: { autoincrement: true } }
     fields:
       content_id: { type: integer, nullable: false }
-      version_id: { type: integer, nullable: false }
-      version_number: { type: integer, nullable: false }
+      version_id: { type: integer, nullable: true }
+      version_number: { type: integer, nullable: true }
       user_id: { type: integer, nullable: false }
       action_timestamp: { type: integer, nullable: false }
       action: { type: string, nullable: false, length: 32 }

--- a/Resources/sql/postgresql/cleandata.sql
+++ b/Resources/sql/postgresql/cleandata.sql
@@ -86,7 +86,7 @@ VALUES (1,1,52,'eng-GB','default');
 INSERT INTO "ezpage_zones" ("id", "name")
 VALUES (1,'default');
 
-SELECT SETVAL('ezdatebasedpublisher_scheduled_version_id_seq', COALESCE(MAX(id), 1)) FROM ezdatebasedpublisher_scheduled_version;
+SELECT SETVAL('ezdatebasedpublisher_scheduled_entries_id_seq', COALESCE(MAX(id), 1)) FROM ezdatebasedpublisher_scheduled_entries;
 SELECT SETVAL('ezeditorialworkflow_markings_id_seq', COALESCE(MAX(id), 1)) FROM ezeditorialworkflow_markings;
 SELECT SETVAL('ezeditorialworkflow_transitions_id_seq', COALESCE(MAX(id), 1)) FROM ezeditorialworkflow_transitions;
 SELECT SETVAL('ezeditorialworkflow_workflows_id_seq', COALESCE(MAX(id), 1)) FROM ezeditorialworkflow_workflows;


### PR DESCRIPTION
**Description**
Schema changes required for "schedule content" feature.

Migration script:
https://github.com/ezsystems/ezplatform-ee/pull/136

TODO:
[x] Merge together with https://github.com/ezsystems/date-based-publisher/pull/172