### PR TITLE
EZEE-3003: Increased ezpage_attributes.value size limit

### DIFF
--- a/Resources/config/storage/schema.yaml
+++ b/Resources/config/storage/schema.yaml
@@ -131,7 +131,7 @@ tables:
       id: { type: integer, nullable: false, options: { autoincrement: true } }
     fields:
       name: { type: string, nullable: false, length: 255, options: { default: '' } }
-      value: { type: text, nullable: true, length: 65535 }
+      value: { type: text, nullable: true, length: 4294967295 }
   ezpage_blocks:
     id:
       id: { type: integer, nullable: false, options: { autoincrement: true } }


### PR DESCRIPTION
> JIRA: https://issues.ibexa.co/browse/EZEE-3003

# Description

This PR fixes issue where big Landing Page cannot be saved because size limit on `ezpage_attribues.value` column is exceeded. It usually happens on long Code Block or more advanced Schedule Block configurations.

The solution to that issue is changing column type to `LONGTEXT` which maxes out at 4GB. `MEDIUMTEXT` (16MB) could be a good choice but you never know what's going on in client databases...  Postgres is not affected because `TEXT` type has no size limit there.

# Upgrade guide

That change requires altering column configuration on current installations:

### MySQL/MariaDB
```sql
ALTER TABLE ezpage_attributes MODIFY value LONGTEXT;
```

### Postgres

No changes needed.